### PR TITLE
Update Obsolete SSL Protocol

### DIFF
--- a/channelfinder/ChannelFinderClient.py
+++ b/channelfinder/ChannelFinderClient.py
@@ -614,6 +614,6 @@ class Ssl3HttpAdapter(HTTPAdapter):
         self.poolmanager = PoolManager(num_pools=connections,
                                        maxsize=maxsize,
                                        block=block,
-                                       ssl_version=ssl.PROTOCOL_SSLv3)
+                                       ssl_version=ssl.PROTOCOL_SSLv23)
 
         


### PR DESCRIPTION
Use of ssl.PROTOCOL_SSLv3 is highly discouraged and is now removed from Python 2.7 in Debian 8 due to security concerns. Recommended to update to ssl.PROTOCOL_SSLv23.  See Python documentation:  https://docs.python.org/2/library/ssl.html#ssl.PROTOCOL_SSLv3