### PR TITLE
Make TLS certificate verification configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ username=MyUserName
 password=MyPassword
 ```
 
+If you are using an `https://` URL and want to disable certificate
+verification, you can add:
+
+```
+verify=false
+```
+
+
 ## Development
 
 To install with dependancies for testing.

--- a/channelfinder/ChannelFinderClient.py
+++ b/channelfinder/ChannelFinderClient.py
@@ -28,7 +28,7 @@ class ChannelFinderClient(object):
     __propertiesResource = "/resources/properties"
     __tagsResource = "/resources/tags"
 
-    def __init__(self, BaseURL=None, username=None, password=None):
+    def __init__(self, BaseURL=None, username=None, password=None, verify=None):
         """
         Channel finder client object. It provides a connection object to perform the following operations:
             - find:     find all channels satisfying given searching criteria
@@ -36,9 +36,13 @@ class ChannelFinderClient(object):
             - update:   update channel information
             - delete:   delete channel from service
 
+        If any of the arguments is ``None``, the respective value from the
+        configuration file is used.
+
         :param BaseURL: the url of the channel finder service
         :param username: user name authorized by channel finder service
         :param password: password for the authorized user
+        :param verify: verify the peer TLS certificate
         """
         self.__baseURL = self.__getDefaultConfig("BaseURL", BaseURL)
         self.__userName = self.__getDefaultConfig("username", username)
@@ -49,17 +53,33 @@ class ChannelFinderClient(object):
             self.__auth = None
         self.__session = requests.Session()
         self.__session.mount(self.__baseURL, HTTPAdapter())
+        if verify is not None:
+            self.__session.verify = verify
+        else:
+            verify_str = self.__getDefaultConfig("verify", None)
+            if verify_str is None:
+                self.__session.verify = True
+            elif verify_str.lower() in ("1", "true", "on", "yes"):
+                self.__session.verify = verify = True
+            elif verify_str.lower() in ("0", "false", "off", "no"):
+                self.__session.verify = verify = False
+            else:
+                # The verify option can also be a path to the trust store, so
+                # if it does not match any of the special strings, we assume
+                # that the string should be used as-is.
+                self.__session.verify = verify_str
 
-    def __getDefaultConfig(self, key, ref):
+    def __getDefaultConfig(self, key, override):
         """
         Get default configuration for given name and section.
 
         :param key: key word
-        :param ref: reference value
-        :return: result if key word is configured or ref is not None, otherwise None
+        :param override: override value
+        :return: ``override`` if not ``None``, else the configuration value
+            associated with ``key`` if present, otherwise ``None``.
         """
-        result = ref
-        if ref is None:
+        result = override
+        if override is None:
             result = basecfg["DEFAULT"].get(key, None)
         return result
 
@@ -153,7 +173,6 @@ class ChannelFinderClient(object):
                 + kwds["channel"]["name"],
                 data=JSONEncoder().encode(kwds["channel"]),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             )
             r.raise_for_status()
@@ -162,7 +181,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__channelsResource,
                 data=JSONEncoder().encode(kwds["channels"]),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             )
             r.raise_for_status()
@@ -171,7 +189,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__tagsResource + "/" + kwds["tag"]["name"],
                 data=JSONEncoder().encode(kwds["tag"]),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             )
             r.raise_for_status()
@@ -181,7 +198,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__tagsResource,
                 data=data,
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             )
             r.raise_for_status()
@@ -193,7 +209,6 @@ class ChannelFinderClient(object):
                 + kwds["property"]["name"],
                 data=JSONEncoder().encode(kwds["property"]),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             )
             r.raise_for_status()
@@ -204,7 +219,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__propertiesResource,
                 data=data,
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             )
             r.raise_for_status()
@@ -230,7 +244,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__tagsResource + "/" + kwds["tag"]["name"],
                 data=JSONEncoder().encode(data),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             ).raise_for_status()
         elif "tag" in kwds and "channelNames" in kwds:
@@ -243,7 +256,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__tagsResource + "/" + kwds["tag"]["name"],
                 data=JSONEncoder().encode(data),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             ).raise_for_status()
         elif "property" in kwds and "channels" in kwds:
@@ -256,7 +268,6 @@ class ChannelFinderClient(object):
                 + kwds["property"]["name"],
                 data=JSONEncoder().encode(data),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             ).raise_for_status()
         else:
@@ -357,7 +368,6 @@ class ChannelFinderClient(object):
             url,
             params=args,
             headers=copy(self.__jsonheader),
-            verify=False,
             auth=self.__auth,
         )
         try:
@@ -377,9 +387,7 @@ class ChannelFinderClient(object):
         :return: Tag object if found, otherwise None
         """
         url = self.__baseURL + self.__tagsResource + "/" + tagname
-        r = self.__session.get(
-            url, headers=copy(self.__jsonheader), verify=False, auth=self.__auth
-        )
+        r = self.__session.get(url, headers=copy(self.__jsonheader), auth=self.__auth)
         try:
             r.raise_for_status()
             return r.json()
@@ -397,7 +405,7 @@ class ChannelFinderClient(object):
         :return: Property object if found, otherwise None
         """
         url = self.__baseURL + self.__propertiesResource + "/" + propertyname
-        r = self.__session.get(url, headers=copy(self.__jsonheader), verify=False)
+        r = self.__session.get(url, headers=copy(self.__jsonheader))
         try:
             r.raise_for_status()
             return r.json()
@@ -414,7 +422,7 @@ class ChannelFinderClient(object):
         :return: list of all the Tag objects present, otherwise None.
         """
         url = self.__baseURL + self.__tagsResource
-        r = self.__session.get(url, headers=copy(self.__jsonheader), verify=False)
+        r = self.__session.get(url, headers=copy(self.__jsonheader))
         try:
             r.raise_for_status()
             return r.json()
@@ -431,7 +439,7 @@ class ChannelFinderClient(object):
         :return: list of the Property objects present, otherwise None
         """
         url = self.__baseURL + self.__propertiesResource
-        r = self.__session.get(url, headers=copy(self.__jsonheader), verify=False)
+        r = self.__session.get(url, headers=copy(self.__jsonheader))
         try:
             r.raise_for_status()
             return r.json()
@@ -496,12 +504,12 @@ class ChannelFinderClient(object):
                 + kwds["channelName"].strip()
             )
             self.__session.delete(
-                url, headers=copy(self.__jsonheader), verify=False, auth=self.__auth
+                url, headers=copy(self.__jsonheader), auth=self.__auth
             ).raise_for_status()
         elif "tagName" in kwds:
             url = self.__baseURL + self.__tagsResource + "/" + kwds["tagName"].strip()
             self.__session.delete(
-                url, verify=False, headers=copy(self.__jsonheader), auth=self.__auth
+                url, headers=copy(self.__jsonheader), auth=self.__auth
             ).raise_for_status()
         elif "propertyName" in kwds:
             url = (
@@ -511,7 +519,7 @@ class ChannelFinderClient(object):
                 + kwds["propertyName"].strip()
             )
             self.__session.delete(
-                url, headers=copy(self.__jsonheader), verify=False, auth=self.__auth
+                url, headers=copy(self.__jsonheader), auth=self.__auth
             ).raise_for_status()
         else:
             raise RuntimeError(
@@ -537,7 +545,6 @@ class ChannelFinderClient(object):
                 + "/"
                 + kwds["channelName"].strip(),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             ).raise_for_status()
         elif "tag" in kwds and "channelNames" in kwds:
@@ -560,7 +567,6 @@ class ChannelFinderClient(object):
                 + "/"
                 + kwds["channelName"],
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             ).raise_for_status()
         elif "property" in kwds and "channelNames" in kwds:
@@ -666,7 +672,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__channelsResource + "/" + ch["name"],
                 data=JSONEncoder().encode(ch),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             )
             r.raise_for_status()
@@ -676,7 +681,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__channelsResource,
                 data=JSONEncoder().encode(chs),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             )
             r.raise_for_status()
@@ -686,7 +690,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__propertiesResource + "/" + property["name"],
                 data=JSONEncoder().encode(property),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             )
             r.raise_for_status()
@@ -696,7 +699,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__tagsResource + "/" + tag["name"],
                 data=JSONEncoder().encode(tag),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             )
             r.raise_for_status()
@@ -705,7 +707,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__tagsResource,
                 data=JSONEncoder().encode(kwds["tags"]),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             )
             r.raise_for_status()
@@ -742,7 +743,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__tagsResource + "/" + tag["name"],
                 data=JSONEncoder().encode(tag),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             ).raise_for_status()
         elif "tag" in kwds and "channelNames" in kwds:
@@ -759,7 +759,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__tagsResource + "/" + tag["name"],
                 data=JSONEncoder().encode(tag),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             ).raise_for_status()
         elif "property" in kwds and "channelName" in kwds:
@@ -778,7 +777,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__propertiesResource + "/" + property["name"],
                 data=JSONEncoder().encode(property),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             ).raise_for_status()
         elif "property" in kwds and "channelNames" in kwds:
@@ -799,7 +797,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__propertiesResource + "/" + property["name"],
                 data=JSONEncoder().encode(property),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             ).raise_for_status()
         elif "originalChannelName" in kwds and "channel" in kwds:
@@ -809,7 +806,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__channelsResource + "/" + channelName,
                 data=JSONEncoder().encode(ch),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             ).raise_for_status()
         elif "originalPropertyName" in kwds and "property" in kwds:
@@ -819,7 +815,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__propertiesResource + "/" + propName,
                 data=JSONEncoder().encode(prop),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             ).raise_for_status()
         elif "originalTagName" in kwds and "tag" in kwds:
@@ -829,7 +824,6 @@ class ChannelFinderClient(object):
                 self.__baseURL + self.__tagsResource + "/" + tagName,
                 data=JSONEncoder().encode(tag),
                 headers=copy(self.__jsonheader),
-                verify=False,
                 auth=self.__auth,
             ).raise_for_status()
         else:


### PR DESCRIPTION
As dicussed in #37, the verification of remote TLS certificates should be configurable, being enabled by default. This PR makes the necessary changes.